### PR TITLE
Use -- delimeter for a modifier by Harry Roberts

### DIFF
--- a/levels/pages/building/building.jade
+++ b/levels/pages/building/building.jade
@@ -84,8 +84,8 @@ block content
 
         .types
           .types__d_b block/
-          .types__d_m   _mod/
-          .types__f_m     block_mod_value.css
+          .types__d_m   --mod/
+          .types__f_m     block--mod--value.css
           .types__f_b block.css
 
         p or the element subdirectory:
@@ -93,8 +93,8 @@ block content
         .types
           .types__d_b block/
           .types__d_e   __element/
-          .types__d_m     _mod/
-          .types__f_m       block__element_mod.css
+          .types__d_m     --mod/
+          .types__f_m       block__element--mod.css
           .types__f_e     block__element.css
           .types__f_b   block.css
     .grid__row

--- a/levels/pages/faq/faq.jade
+++ b/levels/pages/faq/faq.jade
@@ -45,7 +45,7 @@ block content
           li
             a(href="#encapsulating-tag-selector") Can I combine a tag and a class in selector like button.button?
           li
-            a(href="#css-modifier-names") Is this good to name modifiers corresponding to what they have in CSS? Like `.block__element_border-bottom_5px`.
+            a(href="#css-modifier-names") Is this good to name modifiers corresponding to what they have in CSS? Like `.block__element--border-bottom--5px`.
           li
             a(href="#css-nested-elements") What would be a class name for an element inside another element? `.block__elem1__elem2`?
           li
@@ -88,7 +88,7 @@ block content
           :markdown
             ## Why the modifier CSS classes are not represented as a combined selector?
 
-            > BEM recommends to modify blocks like this `<div class="block block_mod">`. Why not to use the simple version like `<div class="block mod">`? Since we now have combined selectors `.block.mod`, it's easy to define all the CSS properties to it.
+            > BEM recommends to modify blocks like this `<div class="block block--mod">`. Why not to use the simple version like `<div class="block mod">`? Since we now have combined selectors `.block.mod`, it's easy to define all the CSS properties to it.
 
             The recommendation to prefix modifier CSS class with its block name has multiple reasons.
 
@@ -105,7 +105,7 @@ block content
             <div class="menu__item button active"></div>
             ```
             All the 3 sit at the same DOM node, so it is imposible to differentiate if we mean `menu__item.active` or `button.active`.
-            Whereas in the prefixed case the naming `button_active` unambiguously says as that this is only the button that has to be
+            Whereas in the prefixed case the naming `button--active` unambiguously says as that this is only the button that has to be
             affected.
 
             Another point is CSS specificity. The combined selectors are more specific (means more important) than single class selectors.
@@ -120,23 +120,23 @@ block content
             If you are already having `.button.active` selector in code, the specificity of your redefining `.header .button` would be exactly
             the same as the specificity of modifier combined selector which makes you dependent on the order of the CSS rules
             declared. Whereas in case of using a prefixed modifier you can always be sure that the cascade selector `.header .button` will
-            overwrite the `.button_active` modifier.
+            overwrite the `.button--active` modifier.
 
             This makes life easier especially for maintainable projects.
 
-            The third point is that looking at the `<div class="block block_mod">` markup you can clearly see the block structure. It is easy
+            The third point is that looking at the `<div class="block block--mod">` markup you can clearly see the block structure. It is easy
             to recognize that we are having a block and its modifier and there is no different interpretations here. Unfortunately a grasp onto
             `<div class="block mod">` code does not give such information. Depending on what are the exact CSS classes sometimes it is impossible
             to recognize if we are having a block and a modifier or a mix of 2 blocks here. This might be even more confusing if the names of the
             entities are complex or contracted/abbreviated (which sometimes happens in big projects).<br/>
             Clear understanding of a block structure especially helps in looking for corresponding code on a file system.
 
-            You will also appreciate `.block_mod` practice when refactoring and use global search over all your project files. Imagine the
+            You will also appreciate `.block--mod` practice when refactoring and use global search over all your project files. Imagine the
             same looking for not-prefixed `.mod` and all the HTML pieces it might be in.
 
-            And lastly, from a development process standpoint the difference between `.block.mod` and `.block_mod` is only one symbol. Using
+            And lastly, from a development process standpoint the difference between `.block.mod` and `.block--mod` is only one symbol. Using
             `-` instead of `.` costs nothing but it brings all the benefits listed above. Moreover, since pre-processor began to support BEM
-            notation, it is pretty natural to write `&_mod` there and finally get a modifier declared as it was recommended.
+            notation, it is pretty natural to write `&--mod` there and finally get a modifier declared as it was recommended.
 
         a(id="custom-tags-for-blocks")
         .raw-text
@@ -151,9 +151,9 @@ block content
 
             This is more likely that you would need to prefix modifier classes with their block name to provide them namespace.
             The details are uncovered in ["Why the modifier CSS classes are prefixed with their parent block name?"](#why-the-modifier-classes-are-prefixed)
-            question. So, finally the custom-tag version of a block is like `<block class="block_mod"/>`. This does not look
-            very different from `<div class="block block_mod">` especially assuming that being tag-independent you can use any
-            custom node and stay with `<block class="block block_mod">`.
+            question. So, finally the custom-tag version of a block is like `<block class="block--mod"/>`. This does not look
+            very different from `<div class="block block--mod">` especially assuming that being tag-independent you can use any
+            custom node and stay with `<block class="block block--mod">`.
 
             Second drawback is that "tag" version makes using the mixes of blocks impossible whereas the "class" version
             represent that naturally by `<div class="block1 block2">`.
@@ -166,13 +166,13 @@ block content
           :markdown
             ## Why do I need to combine block and prefixed modifier class for a modified block?
 
-            > Why does both block's and modifier's class sit together in the modified block like `<div class=”block block_mod”>`?
-            > Everything about a modified block can be decribed in `.block_mod`. If there is something common between 2 modifiers,
+            > Why does both block's and modifier's class sit together in the modified block like `<div class=”block block--mod”>`?
+            > Everything about a modified block can be decribed in `.block--mod`. If there is something common between 2 modifiers,
             > it's possible to use preprocessor's mixins to avoid copy-paste.
 
             This approach is possible thanks to preprocessors. However it brings some drawbacks which you should be aware of.
 
-            In case of combining 2 or more modifiers at the same block `<div class="block_theme_christmas block_size_big">` you
+            In case of combining 2 or more modifiers at the same block `<div class="block--theme--christmas block--size--big">` you
             would get the core block's styles twice. However this depends on the preprocessor algorythms.
 
             When operating modifiers dynamically with JavaScript, additional modifier is more handy. Switching it off would mean
@@ -247,7 +247,7 @@ block content
             into your block, it is much nicer not to waste time searching for all the places where this block can be combined with a global modifier.
             Espacially assuming that such dependencies usually are not described anywhere.
 
-            All this hell can be avoided by encapsulating a modifier in a block like `.block_mod`.
+            All this hell can be avoided by encapsulating a modifier in a block like `.block--mod`.
 
             Indeed using global modifiers makes the resultant code less. However if you measure the real difference in bytes it usually does not
             seem that big. Especially if you are using CSS optimizer which can combine selectors.
@@ -261,8 +261,8 @@ block content
             > If lately someone else would use in their code `<h2 class="button">`, such an encapsulation would prevent
             > a conflict.
 
-            The CSS specificity of such a selector grows. `.button_mod` selector will not overwrite CSS properties of the block, only
-            `button.button_mod` would work. You will need its modifiers to be combined with the tag as well and so do the developers
+            The CSS specificity of such a selector grows. `.button--mod` selector will not overwrite CSS properties of the block, only
+            `button.button--mod` would work. You will need its modifiers to be combined with the tag as well and so do the developers
             who lately would redefine your block.
 
             Lately, when a project goes larger, it's very likely that you may have `input.button`, `span.button` and `a.button`
@@ -284,7 +284,7 @@ block content
             ## Is this good to name modifiers corresponding to what they have in CSS?
 
             > Thanks to mixes, we can create a lot of modifiers which represent CSS properties and assign them to blocks.
-            > But I've heard that "it is bad". For example, this selector `.block__element_border-bottom_5px` was stamped as
+            > But I've heard that "it is bad". For example, this selector `.block__element--border-bottom--5px` was stamped as
             > "awful". I am wondering why and how should the modifiers be named then?
 
             Naming the modifiers corresponding to their CSS representation is not recommended. Indeed it looks not very nice but

--- a/levels/pages/introduction/introduction.jade
+++ b/levels/pages/introduction/introduction.jade
@@ -148,7 +148,7 @@ block content
                 img(src="/img/github_buttons.jpg")
 
               :markdown
-                We can have normal button for usual cases, and two more states for different ones. Because of BEM style blocks by class selectors, we can implement blocks with any tags we want (`button`, `a` or even `div`). Naming invites us to use `block__modifier_value` syntax.
+                We can have normal button for usual cases, and two more states for different ones. Because of BEM style blocks by class selectors, we can implement blocks with any tags we want (`button`, `a` or even `div`). Naming invites us to use `block--modifier--value` syntax.
           .grid__row
             .grid__cell-sm.grid__cell-sm_size_6.raw-text
               h5 HTML
@@ -158,11 +158,11 @@ block content
                   Normal button
                 </button>
 
-                <button class="button button_state_success">
+                <button class="button button--state--success">
                   Success button
                 </button>
 
-                <button class="button button_state_danger">
+                <button class="button button--state--danger">
                   Danger button
                 </button>
                 ```
@@ -180,13 +180,13 @@ block content
                   font: 700 13px/18px Helvetica, arial;
                 }
 
-                .button_state_success {
+                .button--state--success {
                   color: #FFF;
                   background: #569E3D linear-gradient(#79D858, #569E3D) repeat-x;
                   border-color: #4A993E;
                 }
 
-                .button_state_danger {
+                .button--state--danger {
                   color: #900;
                 }
                 ```

--- a/levels/pages/naming/naming.jade
+++ b/levels/pages/naming/naming.jade
@@ -120,10 +120,10 @@ block content
           Modifier can be a boolean flag or a key/value pair:
 
           __Boolean modifiers__<br>
-              Original block/element name + single underscore + mod name: `.block_mod` or `.block__elem_mod`
+              Original block/element name + single underscore + mod name: `.block--mod` or `.block__elem--mod`
 
            __Key/value modifiers__<br>
-              Original block/element name + single underscore + mod key name + single underscore + mod value: `.block_key_value` or `.block__elem_key_value`
+              Original block/element name + single underscore + mod key name + single underscore + mod value: `.block--key--value` or `.block__elem--key--value`
       .grid__cell-md.grid__cell-md_size_4.grid__cell_left-border.raw-text
         :markdown
           #### HTML
@@ -131,13 +131,13 @@ block content
 
           **Good**
           ```html
-          <div class="block block_mod">...</div>
-          <div class="block block_size_big block_shadow_yes">...</div>
+          <div class="block block--mod">...</div>
+          <div class="block block--size--big block--shadow--yes">...</div>
           ```
 
           **Bad**
           ```html
-          <div class="block_mod">...</div>
+          <div class="block--mod">...</div>
           ```
       .grid__cell-md.grid__cell-md_size_4.grid__cell_left-border.raw-text
         :markdown
@@ -151,13 +151,13 @@ block content
           To alter elements based on a block-level modifier:
 
           ```css
-          .block_mod .block__elem { display: none }
+          .block--mod .block__elem { display: none }
           ```
 
           Element modifier:
 
           ```css
-          .block__elem_mod { display: none }
+          .block__elem--mod { display: none }
           ```
     .grid__row
       .grid__cell-xs.grid__cell-xs_size_12.raw-text
@@ -169,10 +169,10 @@ block content
         :markdown
           #### HTML
           ```html
-          <form class="form form_theme_xmas form_simple">
+          <form class="form form--theme--xmas form--simple">
             <input class="form__input" type="text" />
             <input
-              class="form__submit form__submit_disabled"
+              class="form__submit form__submit--disabled"
               type="submit" />
           </form>
           ```
@@ -181,11 +181,11 @@ block content
           #### CSS
           ```css
           .form { /* ... */ }
-          .form_theme_xmas { /* ... */ }
+          .form--theme--xmas { /* ... */ }
           .form_simple { /* ... */ }
           .form__input { /* ... */ }
           .form__submit { /* ... */ }
-          .form__submit_disabled { /* ... */ }
+          .form__submit--disabled { /* ... */ }
           ```
     .authors
       h1.authors__heading Written by


### PR DESCRIPTION
`--` has became a standard for a modifier delimiter. Let's use this convention so that our readers could easily recognise that this is the same BEM which Harry Roberts spoke about and which is currently presented all over the world.