### PR TITLE
Fix href of questionsPanel()'s anchors

### DIFF
--- a/src/views/home.js
+++ b/src/views/home.js
@@ -76,8 +76,8 @@ function questionsPanel() {
 		img: '/assets/ic_question_answer_white_24px.svg',
 		children: (
 			<div>
-				<p><i>— <a href="/faq/#custom-tags-for-blocks">Why do I need CSS classes for block instead of using semantic custom tags?</a></i></p>
-				<p><i>— <a href="/faq/#encapsulating-tag-selector">May I combine a tag and a class in a selector, such as button.button?</a></i></p>
+				<p><i>— <a href="/faq#custom-tags-for-blocks">Why do I need CSS classes for block instead of using semantic custom tags?</a></i></p>
+				<p><i>— <a href="/faq#encapsulating-tag-selector">May I combine a tag and a class in a selector, such as button.button?</a></i></p>
 				<br/>
 				<p>Look for answers in the awesome <a href="/faq/">FAQ list</a>!</p>
 			</div>


### PR DESCRIPTION
Clicking on 1rst or 2nd link of FAQ led to a non-existent page.
Because there was a slash in front of the hash of the anchor's href of those links.
This removes those slashes.