### PR TITLE
Fix failed view load when url has an ID

### DIFF
--- a/src/views/app.js
+++ b/src/views/app.js
@@ -8,9 +8,15 @@ import naming from './naming';
 import faq from './faq';
 
 export default (state) => {
-	const {url} = state;
+	let {url} = state;
 	let page;
 
+	// check to see if an ID is in the URL
+	// if true, concatenate the url to the page address
+	if (url.indexOf('#') > -1) {
+		url = url.split('#')[0];
+	}
+	
 	if (url === '/') {
 		page = home(state);
 	} else if (url === '/introduction/') {


### PR DESCRIPTION
This fix resolves the dead link bug described in issue https://github.com/getbem/getbem.com/issues/147

Currently, the url if statement is looking for a view that does not exist. This is because it is checking against the url post '/'.
i.e. 'faq/#custom-tags-for-blocks' is interpreted as a page rather than the page '/faq' AND an anchor '#custom-tags-for-blocks'.

To solve this, we check to see if the URL contains an ID. If true, we remove the ID and load the appropriate view.